### PR TITLE
no need for index name at overall_funnel calcualtion

### DIFF
--- a/exploratory_analysis/__init__.py
+++ b/exploratory_analysis/__init__.py
@@ -23,6 +23,20 @@ configs = {"date": None,
            "stats": {"host": 'localhost', "port": '9200', 'download_index': 'downloads', 'order_index': 'orders'}
           }
 
+
+schedule_configs = {"date": None,
+           "funnel": {"actions": [],
+                      "purchase_actions": [],
+                      "host": 'localhost',
+                      "port": '9200',
+                      'download_index': 'downloads',
+                      'order_index': 'orders'},
+           "cohort": {"has_download": True, "host": 'localhost', "port": '9200'},
+           "products": {"has_download": True, "host": 'localhost', "port": '9200'},
+           "rfm": {"host": 'localhost', "port": '9200', 'download_index': 'downloads', 'order_index': 'orders'},
+           "stats": {"host": 'localhost', "port": '9200', 'download_index': 'downloads', 'order_index': 'orders'}
+          }
+
 exploratory_analysis = {'funnel': Funnels,
                         'cohort': Cohorts,
                         'products': ProductAnalytics,
@@ -34,7 +48,7 @@ def create_exploratory_analysis(configs):
     ea = {a: exploratory_analysis[a](**configs[a]) for a in exploratory_analysis}
     ea['funnel'].purchase_action_funnel(start_date=configs['date'])
     ea['funnel'].download_signup_session_order_funnel(start_date=configs['date'])
-    ea['funnel'].overall_funnel(start_date=configs['date'], index=configs['funnel']['order_index'])
+    ea['funnel'].overall_funnel(start_date=configs['date'])
     ea['cohort'].execute_cohort(start_date=configs['date'])
     ea['rfm'].execute_rfm(start_date=configs['date'])
     ea['stats'].execute_descriptive_stats(start_date=configs['date'])

--- a/exploratory_analysis/cohorts.py
+++ b/exploratory_analysis/cohorts.py
@@ -470,6 +470,7 @@ class Cohorts:
         _time_period = cohort_name.split("_")[-1]
         boolean_queries, date_queries = [], []
         boolean_queries = [{"term": {"report_name": "cohort"}},
+                           {"term": {"index": get_index_group(self.order_index)}},
                            {"term": {"report_types.time_period": _time_period}},
                            {"term": {"report_types.type": _cohort_type}},
                            {"term": {"report_types.from": _from}},


### PR DESCRIPTION
schedule configs for initialize for ea when scheduling
forget to add
   {"term": {"index": get_index_group(self.order_index)}}
 to cohorts.py